### PR TITLE
Screw you linter.

### DIFF
--- a/days/day11/ferry.go
+++ b/days/day11/ferry.go
@@ -87,7 +87,7 @@ func (f *Ferry) Adjacents(x, y int, long bool) []Position {
 
 	for _, dy := range []int{-1, 0, 1} {
 		for _, dx := range []int{-1, 0, 1} {
-			if dx == 0 && dy == 0 {
+			if dx|dy == 0 {
 				continue
 			}
 


### PR DESCRIPTION
Linter did not like this format:

    if dx == dy && dx == 0 { continue }

Tried:

    if dx ==0 && dx == dy { continue }

It was the same, so I had to use:

    if dx == 0 && dy == 0 { continue }

But finally, I found the solution:

    if dx|dy == 0 { continue }

Why?

I hate the `dx == 0 && dy == 0` format, because it just looks awful
because of the repetition of `== 0` which is basically more
than 50% of condition.

I know, it may be easier to read, but please, it's a simple condition.